### PR TITLE
Check for needed Promise static functions.

### DIFF
--- a/traverse.es5.js
+++ b/traverse.es5.js
@@ -1,5 +1,8 @@
 var this$0 = this;(function(factory ) {
-	var hasPromise = typeof Promise !== 'undefined';
+	var hasPromise = typeof Promise !== 'undefined' &&
+		typeof Promise.cast !== 'undefined' &&
+		typeof Promise.resolve !== 'undefined' &&
+		typeof Promise.all !== 'undefined';
 
 	if (typeof define === 'function' && define.amd) {
 		// loading Promise polyfill only when it's not available natively

--- a/traverse.js
+++ b/traverse.js
@@ -1,5 +1,8 @@
 (factory => {
-	let hasPromise = typeof Promise !== 'undefined';
+	let hasPromise = typeof Promise !== 'undefined' &&
+		typeof Promise.cast !== 'undefined' &&
+		typeof Promise.resolve !== 'undefined' &&
+		typeof Promise.all !== 'undefined';
 
 	if (typeof define === 'function' && define.amd) {
 		// loading Promise polyfill only when it's not available natively


### PR DESCRIPTION
Node 0.11 has Promise but does not have Promise.cast. If any of the the needed
Promise functions are missing fallback to the bluebird implementation.
