### PR TITLE
Test node 0.11 and allow it to fail.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,8 @@
 language: node_js
-node_js: '0.10'
+node_js:
+  - '0.10'
+  - 0.11
+matrix:
+  fast_finish: true
+  allow_failures:
+    - node_js: 0.11


### PR DESCRIPTION
Following http://bocoup.com/weblog/proactive-nodejs-development/ this lets when-traverse test against 0.11 on travis without affecting the badge so that we can prepare when-traverse for 0.12 while letting 0.10 users know when-traverse isn't broken for them. 
