### PR TITLE
json breadcrumb/path

### DIFF
--- a/traverse.es5.js
+++ b/traverse.es5.js
@@ -66,8 +66,6 @@ var this$0 = this;(function(factory ) {
 
 		proto$0.into = function(node, key, parent, path) {var this$0 = this;
 
-			console.log("Node is", node, "path is", path);
-
 			if (!isObject(node) || isSkipped(node)) {
 				return Promise.resolve(node);
 			}

--- a/traverse.es5.js
+++ b/traverse.es5.js
@@ -23,7 +23,7 @@ var this$0 = this;(function(factory ) {
 	var isObject = function(node ) {return typeof node === 'object' && node !== null};
 	var isSkipped = function(node ) {return node === WhenTraverse.SKIP || node === WhenTraverse.REMOVE};
 
-	var WhenTraverse = (function(){
+	var WhenTraverse = (function(){var PRS$0 = (function(o,t){o["__proto__"]={"a":t};return o["a"]===t})({},{});var DP$0 = Object.defineProperty;var GOPD$0 = Object.getOwnPropertyDescriptor;var MIXIN$0 = function(t,s){for(var p in s){if(s.hasOwnProperty(p)){DP$0(t,p,GOPD$0(s,p));}}return t};var proto$0={};
 		function WhenTraverse(node, options) {var this$0 = this;
 			if (!(this instanceof WhenTraverse)) {
 				return new WhenTraverse(node, options);
@@ -34,10 +34,10 @@ var this$0 = this;(function(factory ) {
 					var enter = this._wrapWhen(options.enter);
 					var leave = this._wrapWhen(options.leave);
 
-					this.visit = function(node, key, parentNode)  
-						{return enter(node, key, parentNode)
-						.then(function(node ) {return this$0.into(node)})
-						.then(function(node ) {return isSkipped(node) ? node : leave(node, key, parentNode)})}
+					this.visit = function(node, key, parentNode, path)  
+						{return enter(node, key, parentNode, path)
+						.then(function(node ) {return this$0.into(node, null, null, path)})
+						.then(function(node ) {return isSkipped(node) ? node : leave(node, key, parentNode, path)})}
 					 ;
 
 					break;
@@ -54,17 +54,20 @@ var this$0 = this;(function(factory ) {
 					throw new TypeError('Unsupported visitor config.');
 			}
 
-			return this.visit(node);
-		}
+			return this.visit(node, null, null, []);
+		}DP$0(WhenTraverse,"prototype",{"configurable":false,"enumerable":false,"writable":false});
 
-		WhenTraverse.prototype._wrapWhen = function(func) {var this$0 = this;
-			return func ? (function(node, key, parentNode) 
-				{return asPromise(func.call(this$0, node, key, parentNode))
+		proto$0._wrapWhen = function(func) {var this$0 = this;
+			return func ? (function(node, key, parentNode, path) 
+				{return asPromise(func.call(this$0, node, key, parentNode, path))
 				.then(function(newValue ) {return newValue === undefined ? node : newValue})}
 			) : resolve;
-		}
+		};
 
-		WhenTraverse.prototype.into = function(node) {var this$0 = this;
+		proto$0.into = function(node, key, parent, path) {var this$0 = this;
+
+			console.log("Node is", node, "path is", path);
+
 			if (!isObject(node) || isSkipped(node)) {
 				return Promise.resolve(node);
 			}
@@ -73,7 +76,7 @@ var this$0 = this;(function(factory ) {
 				var subNode = node[key];
 
 				return asPromise(subNode)
-					.then(function(subNode ) {return this$0.visit(subNode, key, node)})
+					.then(function(subNode ) {return this$0.visit(subNode, key, node, path.concat(key))})
 					.then(function(newSubNode ) {
 						if (!isSkipped(newSubNode)) {
 							if (newSubNode !== subNode) {
@@ -86,8 +89,8 @@ var this$0 = this;(function(factory ) {
 						}
 					});
 			})).then(function()  {return node});
-		}
-	;return WhenTraverse;})();
+		};
+	MIXIN$0(WhenTraverse.prototype,proto$0);proto$0=void 0;return WhenTraverse;})();
 
 	// defining non-modifiable constants
 	['SKIP', 'REMOVE'].forEach(function(name ) {return Object.defineProperty(WhenTraverse, name, {enumerable: true, value: {}})});


### PR DESCRIPTION
This creates a json path, as knowing where you are in an object can be very important.

```
let obj = { first: second: third: fourth: true };

whenTraverse(obj, 
  enter: function(node, key, parentNode, path) {
      console.log(path);
  });
```

would output:

```
['first']
['first', 'second']
['first', 'second', 'third']
['first', 'second', 'third', 'fourth']
```

Not tested very thoroughly, just wanted to get it out to see if it would stick and because I need the functionality right now.

On another note, is there any reason you don't just bind a context object to each function?

```
context = { parentNode, key, ... }
promise.bind(context)
```

This way, the function argument could be the node as it currently is, and each chained promise would be returning only what it received:

```
.then( function(node) { return node; } )
```

 Other properties would be available as this.parentNode, etc.
